### PR TITLE
Add contributor permissions to repo page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,36 +8,63 @@
 @import "base/base";
 @import "refills/flashes";
 
-$background-color: #e0e0e0;
-$contributor-background: #fff;
-$base-border-color: #444;
-
 body {
-  background-color: $background-color;
+  background-color: $secondary-background-color;
 }
 
 .scoreboard {
   @include outer-container;
+  margin-bottom: $base-spacing;
+  margin-top: $base-spacing;
 }
 
 .contributor {
-  @include span-columns(6 of 12);
-  background-color: $contributor-background;
+  @include span-columns(8 of 12);
+  background-color: $base-background-color;
   border: 1px solid $base-border-color;
+  clear: both;
   overflow: hidden;
-  padding: $gutter;
+  padding: $base-spacing;
+  padding-top: $base-spacing * 2;
+  position: relative;
 }
 
 .rank {
-  @include span-columns(1 of 6);
+  @include span-columns(1 of 8);
 }
 
 .handle {
-  @include span-columns(3 of 6);
+  @include span-columns(3 of 8);
   font-weight: bold;
 }
 
 .score {
-  @include span-columns(2 of 6);
+  @include span-columns(2 of 8);
   text-align: right;
+}
+
+.permissions {
+  @include fill-parent;
+  height: 2em;
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.permission {
+  color: $base-background-color;
+  display: inline-block;
+  padding: $small-spacing / 4 $small-spacing;
+
+  &-admin {
+    background-color: $blue;
+  }
+
+  &-pull {
+    background-color: $medium-gray;
+  }
+
+  &-push {
+    background-color: $dark-gray;
+  }
 }

--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -1,5 +1,5 @@
 class CollaboratorsController < ApplicationController
   def index
-    @contributors = Repo.new("thoughtbot/administrate").contributors
+    @repo = Repo.new("thoughtbot/administrate")
   end
 end

--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -1,5 +1,5 @@
 class CollaboratorsController < ApplicationController
   def index
-    @scores = Repo.new("thoughtbot/administrate").scores
+    @contributors = Repo.new("thoughtbot/administrate").contributors
   end
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,0 +1,40 @@
+class Contributor
+  include ActiveModel::Model
+
+  attr_accessor :handle
+  attr_writer :pulls, :issues, :pull_comments, :comments
+
+  def score
+    1_000_000 * (
+      10 * score_for_contributions(pulls) +
+      5 * score_for_contributions(issues) +
+      3 * score_for_contributions(pull_comments) +
+      1 * score_for_contributions(comments)
+    )
+  end
+
+  def pulls
+    @pulls || []
+  end
+
+  def issues
+    @issues || []
+  end
+
+  def pull_comments
+    @pull_comments || []
+  end
+
+  def comments
+    @comments || []
+  end
+
+  private
+
+  def score_for_contributions(contribution_collection)
+    contribution_collection.sum do |contribution|
+      time_since_contribution = Time.current - contribution.attrs[:created_at]
+      1.0 / time_since_contribution
+    end
+  end
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -3,6 +3,7 @@ class Contributor
 
   attr_accessor :handle
   attr_writer :pulls, :issues, :pull_comments, :comments
+  attr_accessor :collaborator_info
 
   def score
     1_000_000 * (
@@ -11,6 +12,18 @@ class Contributor
       3 * score_for_contributions(pull_comments) +
       1 * score_for_contributions(comments)
     )
+  end
+
+  def admin_permissions?
+    fetch_permission(:admin, false)
+  end
+
+  def push_permissions?
+    fetch_permission(:push, false)
+  end
+
+  def pull_permissions?
+    fetch_permission(:pull, true)
   end
 
   def pulls
@@ -30,6 +43,14 @@ class Contributor
   end
 
   private
+
+  def fetch_permission(permission_name, fallback)
+    if collaborator_info.present?
+      collaborator_info.attrs[:permissions].attrs[permission_name]
+    else
+      fallback
+    end
+  end
 
   def score_for_contributions(contribution_collection)
     contribution_collection.sum do |contribution|

--- a/app/views/collaborators/index.html.erb
+++ b/app/views/collaborators/index.html.erb
@@ -1,8 +1,22 @@
 <div class="scoreboard">
-  <h1>Contributors</h1>
+  <h1><%= @repo.repo_path %></h1>
 
-  <% @contributors.each_with_index do |contributor, index| %>
+  <% @repo.contributors.each_with_index do |contributor, index| %>
     <div class="contributor">
+      <div class="permissions">
+        <% if contributor.pull_permissions? %>
+          <span class="permission permission-pull">Pull</span>
+        <% end %>
+
+        <% if contributor.push_permissions? %>
+          <span class="permission permission-push">Push</span>
+        <% end %>
+
+        <% if contributor.admin_permissions? %>
+          <span class="permission permission-admin">Admin</span>
+        <% end %>
+      </div>
+
       <span class="rank"><%= index + 1 %></span>
       <span class="handle"><%= contributor.handle %></span>
       <span class="score"><%= contributor.score.to_i %></span>

--- a/app/views/collaborators/index.html.erb
+++ b/app/views/collaborators/index.html.erb
@@ -1,11 +1,11 @@
 <div class="scoreboard">
-  <h1>Scores</h1>
+  <h1>Contributors</h1>
 
-  <% @scores.each_with_index do |(handle, score), index| %>
+  <% @contributors.each_with_index do |contributor, index| %>
     <div class="contributor">
       <span class="rank"><%= index + 1 %></span>
-      <span class="handle"><%= handle %></span>
-      <span class="score"><%= score.to_i %></span>
+      <span class="handle"><%= contributor.handle %></span>
+      <span class="score"><%= contributor.score.to_i %></span>
     </div>
   <% end %>
 </div>

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -12,14 +12,75 @@ describe Contributor do
     end
 
     it "weighs different contributions according to their value" do
-      pull = Contributor.new(pulls: [stub_contribution(handle: "pull_contributor")])
-      issue = Contributor.new(issues: [stub_contribution(handle: "issue_contributor")])
-      pull_comment = Contributor.new(pull_comments: [stub_contribution(handle: "pull_comment_contributor")])
-      issue_comment = Contributor.new(comments: [stub_contribution(handle: "issue_comment_contributor")])
+      pull = Contributor.new(pulls: [stub_contribution(handle: "pull")])
+      issue = Contributor.new(issues: [stub_contribution(handle: "issue")])
+      pull_comment = Contributor.new(
+        pull_comments: [stub_contribution(handle: "pull_comment")]
+      )
+      issue_comment = Contributor.new(
+        comments: [stub_contribution(handle: "issue_comment")]
+      )
 
       expect(pull.score).to be > issue.score
       expect(issue.score).to be > pull_comment.score
       expect(pull_comment.score).to be > issue_comment.score
+    end
+  end
+
+  describe "#admin_permissions?" do
+    it "reads the permissions from the collaborator object" do
+      admin_info = stub_collaborator(admin: true)
+      non_admin_info = stub_collaborator(admin: false)
+
+      admin = Contributor.new(collaborator_info: admin_info)
+      non_admin = Contributor.new(collaborator_info: non_admin_info)
+
+      expect(admin.admin_permissions?).to be_truthy
+      expect(non_admin.admin_permissions?).to be_falsey
+    end
+
+    it "defaults to false" do
+      contributor = Contributor.new
+
+      expect(contributor.admin_permissions?).to be_falsey
+    end
+  end
+
+  describe "#pull_permissions?" do
+    it "reads the permissions from the collaborator object" do
+      puller_info = stub_collaborator(pull: true)
+      non_puller_info = stub_collaborator(pull: false)
+
+      puller = Contributor.new(collaborator_info: puller_info)
+      non_puller = Contributor.new(collaborator_info: non_puller_info)
+
+      expect(puller.pull_permissions?).to be_truthy
+      expect(non_puller.pull_permissions?).to be_falsey
+    end
+
+    it "defaults to true" do
+      contributor = Contributor.new
+
+      expect(contributor.pull_permissions?).to be_truthy
+    end
+  end
+
+  describe "#push_permissions?" do
+    it "reads the permissions from the collaborator object" do
+      pusher_info = stub_collaborator(push: true)
+      non_pusher_info = stub_collaborator(push: false)
+
+      pusher = Contributor.new(collaborator_info: pusher_info)
+      non_pusher = Contributor.new(collaborator_info: non_pusher_info)
+
+      expect(pusher.push_permissions?).to be_truthy
+      expect(non_pusher.push_permissions?).to be_falsey
+    end
+
+    it "defaults to false" do
+      contributor = Contributor.new
+
+      expect(contributor.push_permissions?).to be_falsey
     end
   end
 end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Contributor do
+  include GithubApiHelpers
+
+  describe "#score" do
+    it "weighs recent contributions more heavily than older contributions" do
+      newer = Contributor.new(pulls: [stub_contribution(created_at: 1.day.ago)])
+      older = Contributor.new(pulls: [stub_contribution(created_at: 2.day.ago)])
+
+      expect(newer.score).to be > older.score
+    end
+
+    it "weighs different contributions according to their value" do
+      pull = Contributor.new(pulls: [stub_contribution(handle: "pull_contributor")])
+      issue = Contributor.new(issues: [stub_contribution(handle: "issue_contributor")])
+      pull_comment = Contributor.new(pull_comments: [stub_contribution(handle: "pull_comment_contributor")])
+      issue_comment = Contributor.new(comments: [stub_contribution(handle: "issue_comment_contributor")])
+
+      expect(pull.score).to be > issue.score
+      expect(issue.score).to be > pull_comment.score
+      expect(pull_comment.score).to be > issue_comment.score
+    end
+  end
+end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -1,106 +1,62 @@
 require "rails_helper"
 
 describe Repo do
-  describe "#scores" do
-    it "fetches pull requests from the repository" do
+  include GithubApiHelpers
+
+  describe "#contributors" do
+    it "returns a list of contributors to the repo" do
+      stub_github_data(pulls: [stub_contribution(handle: "foobar")])
+      repo = Repo.new("graysonwright/osbot")
+
+      contributors = repo.contributors
+
+      expect(contributors.first.handle).to eq("foobar")
+    end
+
+    it "assigns pull requests from the repository to their author" do
       handle = "foobar"
       stub_github_data(pulls: [stub_contribution(handle: handle)])
       repo = Repo.new("graysonwright/osbot")
 
-      scores = repo.scores
+      contributor = repo.contributors.first
 
-      expect(scores[handle]).to be > 0
+      expect(contributor.handle).to eq(handle)
+      expect(contributor.score).to be > 0
     end
 
-    it "fetches issues from the repository" do
+    it "assigns issues from the repository to their author" do
       handle = "foobar"
       stub_github_data(issues: [stub_contribution(handle: handle)])
       repo = Repo.new("graysonwright/osbot")
 
-      scores = repo.scores
+      contributor = repo.contributors.first
 
-      expect(scores[handle]).to be > 0
+      expect(contributor.handle).to eq(handle)
+      expect(contributor.score).to be > 0
     end
 
-    it "fetches issue comments from the repository" do
+    it "assigns issue comments from the repository to their author" do
       handle = "foobar"
       stub_github_data(issues_comments: [stub_contribution(handle: handle)])
       repo = Repo.new("graysonwright/osbot")
 
-      scores = repo.scores
+      contributor = repo.contributors.first
 
-      expect(scores[handle]).to be > 0
+      expect(contributor.handle).to eq(handle)
+      expect(contributor.score).to be > 0
     end
 
-    it "fetches pull request comments from the repository" do
+    it "assigns pull request comments from the repository to their author" do
       handle = "foobar"
       stub_github_data(pulls_comments: [stub_contribution(handle: handle)])
       repo = Repo.new("graysonwright/osbot")
 
-      scores = repo.scores
+      contributor = repo.contributors.first
 
-      expect(scores[handle]).to be > 0
+      expect(contributor.handle).to eq(handle)
+      expect(contributor.score).to be > 0
     end
 
-    it "does not list scores for people who haven't contributed" do
-      stub_github_data
-      repo = Repo.new("graysonwright/osbot")
-
-      scores = repo.scores
-
-      expect(scores["graysonwright"]).to be_nil
-    end
-
-    it "weighs recent contributions more heavily than older contributions" do
-      stub_github_data(pulls: [
-        stub_contribution(created_at: 1.day.ago, handle: "newer_contributor"),
-        stub_contribution(created_at: 2.day.ago, handle: "older_contributor"),
-      ])
-      repo = Repo.new("graysonwright/osbot")
-
-      scores = repo.scores
-
-      expect(scores["newer_contributor"]).to be > scores["older_contributor"]
-    end
-
-    it "weighs different contributions according to their value" do
-      stub_github_data(
-        pulls: [stub_contribution(handle: "pull_contributor")],
-        issues: [stub_contribution(handle: "issue_contributor")],
-        pulls_comments: [stub_contribution(handle: "pull_comment_contributor")],
-        issues_comments: [stub_contribution(handle: "issue_comment_contributor")],
-      )
-      repo = Repo.new("graysonwright/osbot")
-
-      scores = repo.scores
-
-      expect(scores["pull_contributor"]).to be > scores["issue_contributor"]
-      expect(scores["issue_contributor"]).to be > scores["pull_comment_contributor"]
-      expect(scores["pull_comment_contributor"]).to be > scores["issue_comment_contributor"]
-    end
-
-    def stub_github_data(attributes = {})
-      default_attributes = {
-        issues: [],
-        issues_comments: [],
-        pulls: [],
-        pulls_comments: [],
-        login: true,
-      }
-
-      fake_github_client = double(default_attributes.merge(attributes))
-      allow(Octokit::Client).to receive(:new).and_return(fake_github_client)
-
-      fake_github_client
-    end
-
-    def stub_contribution(handle: "foobar", created_at: 1.day.ago)
-      double(
-        attrs: {
-          created_at: created_at,
-          user: double(attrs: { login: handle }),
-        }
-      )
-    end
+    it "excludes people who have access to the repo but haven't contributed"
   end
 end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -13,6 +13,27 @@ describe Repo do
       expect(contributors.first.handle).to eq("foobar")
     end
 
+    it "assigns the permissions from the repository to the contributors" do
+      handle = "foobar"
+      collaborator_info = stub_collaborator(
+        handle: handle,
+        admin: true,
+        push: true,
+        pull: true
+      )
+      stub_github_data(
+        collabs: [collaborator_info],
+        pulls: [stub_contribution(handle: handle)],
+      )
+      repo = Repo.new("graysonwright/osbot")
+
+      contributor = repo.contributors.first
+
+      expect(contributor.admin_permissions?).to be_truthy
+      expect(contributor.push_permissions?).to be_truthy
+      expect(contributor.pull_permissions?).to be_truthy
+    end
+
     it "assigns pull requests from the repository to their author" do
       handle = "foobar"
       stub_github_data(pulls: [stub_contribution(handle: handle)])

--- a/spec/support/github_api_helpers.rb
+++ b/spec/support/github_api_helpers.rb
@@ -1,9 +1,11 @@
 module GithubApiHelpers
   def stub_contribution(handle: "foobar", created_at: 1.day.ago)
-    double(attrs: {
-      created_at: created_at,
-      user: double(attrs: { login: handle}),
-    })
+    double(
+      attrs: {
+        created_at: created_at,
+        user: double(attrs: { login: handle }),
+      }
+    )
   end
 
   def stub_github_data(attributes = {})
@@ -13,11 +15,27 @@ module GithubApiHelpers
       pulls: [],
       pulls_comments: [],
       login: true,
+      collabs: [],
     }
 
     fake_github_client = double(default_attributes.merge(attributes))
     allow(Octokit::Client).to receive(:new).and_return(fake_github_client)
 
     fake_github_client
+  end
+
+  def stub_collaborator(handle: "foobar", admin: false, push: false, pull: true)
+    double(
+      attrs: {
+        login: handle,
+        permissions: double(
+          attrs: {
+            admin: admin,
+            push: push,
+            pull: pull,
+          }
+        ),
+      }
+    )
   end
 end

--- a/spec/support/github_api_helpers.rb
+++ b/spec/support/github_api_helpers.rb
@@ -1,0 +1,23 @@
+module GithubApiHelpers
+  def stub_contribution(handle: "foobar", created_at: 1.day.ago)
+    double(attrs: {
+      created_at: created_at,
+      user: double(attrs: { login: handle}),
+    })
+  end
+
+  def stub_github_data(attributes = {})
+    default_attributes = {
+      issues: [],
+      issues_comments: [],
+      pulls: [],
+      pulls_comments: [],
+      login: true,
+    }
+
+    fake_github_client = double(default_attributes.merge(attributes))
+    allow(Octokit::Client).to receive(:new).and_return(fake_github_client)
+
+    fake_github_client
+  end
+end


### PR DESCRIPTION
Closes #2.
## Feature:

As a contributor,
when I visit the page for a repository,
I want to see who has push permissions on the repo
so I know who can merge in my pull requests.
## Implementation:

Use [the Github API's `#collabs` method](http://octokit.github.io/octokit.rb/Octokit/Client/Repositories.html#collaborators-instance_method) to pull down information about each of the collaborators on a project.  The collaborator information contains fields denoting whether a collaborator is an admin, or has push or pull permissions on the repo.
## To Do:
- [x] Display contributors' permissions on the repository page
- [x] If a contributor does not have collaborator info, then that likely means that they can pull the repository, but do not have admin or push permissions. We should add tests to cover that case.
- [x] Rebase and merge on top of #1 once it is merged in
