### PR TITLE
Fix hard-coded API call to thoughtbot/administrate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,8 +308,5 @@ DEPENDENCIES
   web-console
   webmock
 
-RUBY VERSION
-   ruby 2.3.0p0
-
 BUNDLED WITH
    1.12.3

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -43,7 +43,7 @@ class Repo
 
   def collaborators
     @collaborators ||= cache("github/collaborators") do
-      client.collabs("thoughtbot/administrate")
+      client.collabs(repo_path)
     end
   end
 


### PR DESCRIPTION
In f87f6ba, we generalized the API calls
to use the repository specified in the URL.
We missed one call, to the `collabs` endpoint on the GitHub API.
