### PR TITLE
Update nokogiri for a security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0221)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     multipart-post (2.0.0)
     neat (1.7.4)
@@ -126,12 +126,14 @@ GEM
       sass (>= 3.3)
     netrc (0.11.0)
     newrelic_rpm (3.15.1.316)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     normalize-rails (3.0.3)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
     pg (0.18.4)
+    pkg-config (1.1.7)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -308,5 +310,8 @@ DEPENDENCIES
   web-console
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.12.3
+   1.12.5


### PR DESCRIPTION
## Problem:

The `bundle-audit` command reported a vulnerability in nokogiri:

```
Name: nokogiri
Version: 1.6.7.2
Advisory: CVE-2015-8806
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1473
Title: Denial of service or RCE from libxml2 and libxslt
Solution: upgrade to >= 1.6.8

Vulnerabilities found!
```
## Solution:

Run `bundle update nokogiri`
